### PR TITLE
Fixed list_exchange and list_queues actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.3.0
+
+- Fixed broken `list_exchanges` and `list_queues` actions
+- Note that format of `list_queues` output has changed, due to RabbitMQ changes
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/actions/list_exchanges.py
+++ b/actions/list_exchanges.py
@@ -7,7 +7,8 @@ from lib.shell import run_command
 
 
 def list_exchanges(vhost=None):
-    cmd = ['rabbitmqadmin', 'list', 'exchanges']
+    cmd = ['rabbitmqadmin', 'list', 'exchanges', 'vhost', 'name',
+           'type', 'auto_delete', 'durable', 'internal']
 
     if vhost:
         cmd += ['-V', vhost]
@@ -45,4 +46,4 @@ if __name__ == '__main__':
     vhost = sys.argv[1] if len(sys.argv) > 1 else None
     vhost = vhost if vhost else None
     result = list_exchanges(vhost=vhost)
-    print(json.dumps(result))
+    print json.dumps(result)

--- a/actions/list_queues.py
+++ b/actions/list_queues.py
@@ -24,21 +24,11 @@ QUEUE_ATTRIBUTES = [
     # queue info
     ('messages', int),
     ('messages_ready', int),
+    ('messages_ready_ram', int),
     ('messages_unacknowledged', int),
     ('consumers', int),
     ('memory', int),
     ('state', str),
-
-    # backing store info
-    ('backing_queue_status.len', int),
-    ('backing_queue_status.pending_acks', int),
-    ('backing_queue_status.ram_msg_count', int),
-    ('backing_queue_status.ram_ack_count', int),
-    ('backing_queue_status.persistent_count', int),
-    ('backing_queue_status.avg_ingress_rate', float),
-    ('backing_queue_status.avg_egress_rate', float),
-    ('backing_queue_status.avg_ack_ingress_rate', float),
-    ('backing_queue_status.avg_ack_egress_rate', float)
 ]
 
 
@@ -78,4 +68,4 @@ def list_queues():
 
 if __name__ == '__main__':
     result = list_queues()
-    print(json.dumps(result))
+    print json.dumps(result)

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 ref: rabbitmq
 name : rabbitmq
-description : st2 content pack containing rabbitmq integrations
+description : RabbitMQ integration
 keywords:
   - rabbitmq
   - queuing
@@ -9,6 +9,6 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version : 0.2.0
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
RabbitMQ has changed some of the info returned by `rabbitmqadmin list queues`, and changed the default info returned by `rabbitmqadmin list exchanges`. See https://groups.google.com/forum/#!topic/rabbitmq-users/ivUAQ1vZsro

PR fixes https://github.com/StackStorm-Exchange/stackstorm-rabbitmq/issues/1