### PR TITLE
Fixing broken queues sensor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 0.5.2
+
+- Fixed bug in `queues_sensor` where the channel wasn't calling `basic_consume` with the correct arguments
+- Fixed bug in `queues sensor` where the trigger type of `rabbitmq.new_message` had an incorrect type of `object` for the parameter `body` when instead it should have be a `string`.
+  
+  Contributed by Nick Maludy (@nmaludy Encore Technologies)
+
 # 0.5.0
 
 - Updated to pika 0.11.x, updated exchange\_type parameter, import re-ordering

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version: 0.5.1
+version: 0.5.2
 python_versions:
   - "2"
   - "3"

--- a/sensors/queues_sensor.py
+++ b/sensors/queues_sensor.py
@@ -74,7 +74,7 @@ class RabbitMQQueueSensor(Sensor):
             def callback(ch, method, properties, body, queue_copy=queue):
                 self._dispatch_trigger(ch, method, properties, body, queue_copy)
 
-            self.channel.basic_consume(callback, queue=queue)
+            self.channel.basic_consume(queue, callback)
 
     def _dispatch_trigger(self, ch, method, properties, body, queue):
         body = self._deserialize_body(body=body)

--- a/sensors/queues_sensor.yaml
+++ b/sensors/queues_sensor.yaml
@@ -12,4 +12,4 @@
           queue:
             type: "string"
           body:
-            type: "object"
+            type: "string"


### PR DESCRIPTION
Found out via Slack that the `queues_sensor` wasn't emitting triggers.

Did a little digging and found two problems:
1. `BlockingChannel.basic_consume()` was being called with arguments in the wrong order. According to the documentation, it should be `(queue, callback)` not `(callback, queue=queue)`: https://pika.readthedocs.io/en/stable/modules/adapters/blocking.html#pika.adapters.blocking_connection.BlockingChannel.basic_consume
2. The return data type for the trigger's `body` parameter should be `string` and not `object`.