### PR TITLE
added decode to dispatch_trigger

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,11 @@
 # Change Log
 
-# 0.6.0
+# 0.5.3
 
 - Fixed bug in `queues_sensor` where the parameter `body` was being returned as `byte` and not a `string`
 
   Contributed by Rick Kauffman (@netwookie wookieware.com)
-  
+
 # 0.5.2
 
 - Fixed bug in `queues_sensor` where the channel wasn't calling `basic_consume` with the correct arguments

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,16 @@
 # Change Log
 
+# 0.6.0
+
+- Fixed bug in `queues_sensor` where the parameter `body` was being returned as `byte` and not a `string`
+
+  Contributed by Rick Kauffman (@netwookie wookieware.com)
+  
 # 0.5.2
 
 - Fixed bug in `queues_sensor` where the channel wasn't calling `basic_consume` with the correct arguments
 - Fixed bug in `queues sensor` where the trigger type of `rabbitmq.new_message` had an incorrect type of `object` for the parameter `body` when instead it should have be a `string`.
-  
+
   Contributed by Nick Maludy (@nmaludy Encore Technologies)
 
 # 0.5.0
@@ -30,4 +36,4 @@
 
 # 0.1.0
 
-- First release 
+- First release

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version: 0.6.0
+version: 0.5.3
 python_versions:
   - "2"
   - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version: 0.5.2
+version: 0.6.0
 python_versions:
   - "2"
   - "3"

--- a/sensors/queues_sensor.py
+++ b/sensors/queues_sensor.py
@@ -79,7 +79,7 @@ class RabbitMQQueueSensor(Sensor):
     def _dispatch_trigger(self, ch, method, properties, body, queue):
         body = self._deserialize_body(body=body)
         self._logger.debug('Received message for queue %s with body %s', queue, body)
-
+        body = body.decode('utf-8')
         payload = {"queue": queue, "body": body}
         try:
             self._sensor_service.dispatch(trigger="rabbitmq.new_message", payload=payload)


### PR DESCRIPTION
I noted that there was a small "b" in front of the body variable. Dispatch_trigger complained the variable was not a string. I added the body.decode('utf-8')  