### PR TITLE
Enable Quorum Queue types for Sensor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.1.0
+- Added key to sensor config schema to identify a queue as type: quorum
+- Updated setup() to understand how to create/load queues with types: ["classic", "quorum"]
+
 # 1.0.0
 
 * Drop Python 2.7 support

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ and edit as required.
 * ``username`` - Username to connect to RabbitMQ (optional).
 * ``password`` - Password to connect to RabbitMQ (optional).
 * ``queues`` - List of queues to check for messages. See an example below.
+* ``quorum_queues`` - List of queues defined in `queues` that should be handled as `type: quorum`
 * ``deserialization_method`` - Which method to use to de-serialize the
   message body. By default, no deserialization method is specified which means
   the message body is left as it is. Valid values are ``json`` and ``pickle``.
@@ -28,6 +29,8 @@ sensor_config:
       - queue1
       - queue2
       - ....
+    quorum_queues:
+      - queue2
 ```
 
 ## Actions

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,37 +1,43 @@
 ---
-  sensor_config:
-    description: "RabbitMQ Sensor settings"
-    type: "object"
-    required: true
-    additionalProperties: true
-    properties:
-      host:
-        description: "RabbitMQ host to connect to"
-        type: "string"
-        required: true
-      username:
-        description: "Optional username for RabbitMQ"
-        type: "string"
-      password:
-        description: "Optional password for RabbitMQ"
-        type: "string"
-        secret: true
-      rabbitmq_queue_sensor:
-        description: "Queue settings"
-        type: "object"
-        required: true
-        additionalProperties: true
-        properties:
-          queues:
-            description: "List of queues to monitor"
-            type: "array"
-            items:
-              type: "string"
-              required: true
-          deserialization_method:
-            description: "Method used to de-serialize body. Default is to leave body as-is"
+sensor_config:
+  description: "RabbitMQ Sensor settings"
+  type: "object"
+  required: true
+  additionalProperties: true
+  properties:
+    host:
+      description: "RabbitMQ host to connect to"
+      type: "string"
+      required: true
+    username:
+      description: "Optional username for RabbitMQ"
+      type: "string"
+    password:
+      description: "Optional password for RabbitMQ"
+      type: "string"
+      secret: true
+    rabbitmq_queue_sensor:
+      description: "Queue settings"
+      type: "object"
+      required: true
+      additionalProperties: true
+      properties:
+        queues:
+          description: "List of queues to monitor"
+          type: "array"
+          items:
             type: "string"
-            enum:
-              - "json"
-              - "pickle"
+            required: true
+        quorum_queues:
+          description: "List of queues with quorum type"
+          type: "array"
+          items:
+            type: "string"
             required: false
+        deserialization_method:
+          description: "Method used to de-serialize body. Default is to leave body as-is"
+          type: "string"
+          enum:
+            - "json"
+            - "pickle"
+          required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version: 1.0.1
+version: 1.1.0
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,7 +1,7 @@
 ---
 ref: rabbitmq
-name : rabbitmq
-description : RabbitMQ integration
+name: rabbitmq
+description: RabbitMQ integration
 keywords:
   - rabbitmq
   - queuing
@@ -9,8 +9,8 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version: 1.0.0
+version: 1.0.1
 python_versions:
   - "3"
-author : StackStorm, Inc.
-email : info@stackstorm.com
+author: StackStorm, Inc.
+email: info@stackstorm.com

--- a/sensors/queues_sensor.py
+++ b/sensors/queues_sensor.py
@@ -8,10 +8,7 @@ import eventlet
 
 from st2reactor.sensor.base import Sensor
 
-DESERIALIZATION_FUNCTIONS = {
-    'json': json.loads,
-    'pickle': pickle.loads
-}
+DESERIALIZATION_FUNCTIONS = {"json": json.loads, "pickle": pickle.loads}
 
 
 class RabbitMQQueueSensor(Sensor):
@@ -23,30 +20,44 @@ class RabbitMQQueueSensor(Sensor):
     It is capable of simultaneously consuming from multiple queues. Each message is
     dispatched to stackstorm as a `rabbitmq.new_message` TriggerInstance.
     """
+
     def __init__(self, sensor_service, config=None):
-        super(RabbitMQQueueSensor, self).__init__(sensor_service=sensor_service, config=config)
+        super(RabbitMQQueueSensor, self).__init__(
+            sensor_service=sensor_service, config=config
+        )
 
         self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
-        self.host = self._config['sensor_config']['host']
-        self.username = self._config['sensor_config']['username']
-        self.password = self._config['sensor_config']['password']
+        self.host = self._config["sensor_config"]["host"]
+        self.username = self._config["sensor_config"]["username"]
+        self.password = self._config["sensor_config"]["password"]
 
-        queue_sensor_config = self._config['sensor_config']['rabbitmq_queue_sensor']
-        self.queues = queue_sensor_config['queues']
+        queue_sensor_config = self._config["sensor_config"]["rabbitmq_queue_sensor"]
+        self.queues = queue_sensor_config["queues"]
         if not isinstance(self.queues, list):
             self.queues = [self.queues]
-        self.deserialization_method = queue_sensor_config['deserialization_method']
+
+        self.quorum_queues = queue_sensor_config.get("quorum_queues", list())
+        self.deserialization_method = queue_sensor_config.get(
+            "deserialization_method", "json"
+        )
 
         supported_methods = DESERIALIZATION_FUNCTIONS.keys()
-        if self.deserialization_method and self.deserialization_method not in supported_methods:
-            raise ValueError('Invalid deserialization method specified: %s' %
-                             (self.deserialization_method))
+        if (
+            self.deserialization_method
+            and self.deserialization_method not in supported_methods
+        ):
+            raise ValueError(
+                "Invalid deserialization method specified: %s"
+                % (self.deserialization_method)
+            )
 
         self.conn = None
         self.channel = None
 
     def run(self):
-        self._logger.info('Starting to consume messages from RabbitMQ for %s', self.queues)
+        self._logger.info(
+            "Starting to consume messages from RabbitMQ for %s", self.queues
+        )
         # run in an eventlet in-order to yield correctly
         gt = eventlet.spawn(self.channel.start_consuming)
         # wait else the sensor will quit
@@ -58,8 +69,12 @@ class RabbitMQQueueSensor(Sensor):
 
     def setup(self):
         if self.username and self.password:
-            credentials = PlainCredentials(username=self.username, password=self.password)
-            connection_params = pika.ConnectionParameters(host=self.host, credentials=credentials)
+            credentials = PlainCredentials(
+                username=self.username, password=self.password
+            )
+            connection_params = pika.ConnectionParameters(
+                host=self.host, credentials=credentials
+            )
         else:
             connection_params = pika.ConnectionParameters(host=self.host)
 
@@ -67,9 +82,16 @@ class RabbitMQQueueSensor(Sensor):
         self.channel = self.conn.channel()
         self.channel.basic_qos(prefetch_count=1)
 
+        quorum_args = {"x-queue-type": "quorum"}
+
         # Setup Qs for listening
         for queue in self.queues:
-            self.channel.queue_declare(queue=queue, durable=True)
+            if queue not in self.quorum_queues:
+                self.channel.queue_declare(queue=queue, durable=True)
+            else:
+                self.channel.queue_declare(
+                    queue=queue, durable=True, arguments=quorum_args
+                )
 
             def callback(ch, method, properties, body, queue_copy=queue):
                 self._dispatch_trigger(ch, method, properties, body, queue_copy)
@@ -78,11 +100,13 @@ class RabbitMQQueueSensor(Sensor):
 
     def _dispatch_trigger(self, ch, method, properties, body, queue):
         body = self._deserialize_body(body=body)
-        self._logger.debug('Received message for queue %s with body %s', queue, body)
-        body = body.decode('utf-8')
+        self._logger.debug("Received message for queue %s with body %s", queue, body)
+        body = body.decode("utf-8")
         payload = {"queue": queue, "body": body}
         try:
-            self._sensor_service.dispatch(trigger="rabbitmq.new_message", payload=payload)
+            self._sensor_service.dispatch(
+                trigger="rabbitmq.new_message", payload=payload
+            )
         finally:
             self.channel.basic_ack(delivery_tag=method.delivery_tag)
 


### PR DESCRIPTION
This PR adds a config scheme optional key of `quorum_queues`.
When used in conjunction with a similarly named queue in `queues`, `queues_sensor.py` will now honor that by adding `arguments={"x-queue-type": "quorum"}` and performing the same as the original logic.

Other changes present look to be the result for my black/YAML linter auto fixing formatting.

I also fixed deserialization_method to actually be `required: false`, as it actually had no logic to express a default when `None` is passed.

```python
- self.deserialization_method = queue_sensor_config['deserialization_method']
+ self.deserialization_method = queue_sensor_config.get("deserialization_method", "json")
```
## Testing
I tested with various combinations of pre-existing queues and non-existing queues to test that creation/consumption behaviors still work. I also tested with mix of queues defined in `queues` and `quorum_queues` with expected results.

Then i tested a config with no key for `queues` (which failed spectacularly, as expected) as well as with `queues: []`, to which i got a graceful exit code of `0` (rather than the message `queues_sensor [-] Starting to consume messages from RabbitMQ for ['<queue name>']`)

## versioning
```bash
# rabbitmqctl version
3.10.7

# st2 --version
st2 3.7.0, on Python 3.8.10

# cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.4 LTS"
```