### PR TITLE
add virtual host connection params into RabbitMQQueueSensor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+# 1.1.2
+- Added virtual_host connection parameter to `queues_sensor`
+
 # 1.1.1
 - Updated pip dependency to pika `1.3.x` to support python >= 3.7
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and edit as required.
 * ``host`` - RabbitMQ host to connect to.
 * ``username`` - Username to connect to RabbitMQ (optional).
 * ``password`` - Password to connect to RabbitMQ (optional).
-* ``virtual_host`` - RabbiqMQ virtual host to use (optional).
+* ``virtual_host`` - RabbitMQ virtual host to use.
 * ``queues`` - List of queues to check for messages. See an example below.
 * ``quorum_queues`` - List of queues defined in `queues` that should be handled as `type: quorum`
 * ``deserialization_method`` - Which method to use to de-serialize the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and edit as required.
 * ``host`` - RabbitMQ host to connect to.
 * ``username`` - Username to connect to RabbitMQ (optional).
 * ``password`` - Password to connect to RabbitMQ (optional).
+* ``virtual_host`` - RabbiqMQ virtual host to use (optional).
 * ``queues`` - List of queues to check for messages. See an example below.
 * ``quorum_queues`` - List of queues defined in `queues` that should be handled as `type: quorum`
 * ``deserialization_method`` - Which method to use to de-serialize the

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -16,6 +16,9 @@ sensor_config:
       description: "Optional password for RabbitMQ"
       type: "string"
       secret: true
+    virtual_host:
+      description: "Optional virtual host for RabbitMQ"
+      type: "string"
     rabbitmq_queue_sensor:
       description: "Queue settings"
       type: "object"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -17,8 +17,10 @@ sensor_config:
       type: "string"
       secret: true
     virtual_host:
-      description: "Optional virtual host for RabbitMQ"
       type: "string"
+      description: "RabbitMQ virtual host to use"
+      required: true
+      default: "/"
     rabbitmq_queue_sensor:
       description: "Queue settings"
       type: "object"

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version: 1.1.1
+version: 1.1.2
 python_versions:
   - "3"
 author: StackStorm, Inc.

--- a/sensors/queues_sensor.py
+++ b/sensors/queues_sensor.py
@@ -30,7 +30,7 @@ class RabbitMQQueueSensor(Sensor):
         self.host = self._config["sensor_config"]["host"]
         self.username = self._config["sensor_config"]["username"]
         self.password = self._config["sensor_config"]["password"]
-        self.virtual_host = self._config["sensor_config"]["virtual_host"] if 'virtual_host' in self._config["sensor_config"].keys() else None
+        self.virtual_host = self._config["sensor_config"]["virtual_host"]
 
         queue_sensor_config = self._config["sensor_config"]["rabbitmq_queue_sensor"]
         self.queues = queue_sensor_config["queues"]
@@ -74,12 +74,10 @@ class RabbitMQQueueSensor(Sensor):
                 username=self.username, password=self.password
             )
             connection_params = pika.ConnectionParameters(
-                host=self.host, credentials=credentials
+                host=self.host, credentials=credentials, virtual_host=self.virtual_host
             )
         else:
-            connection_params = pika.ConnectionParameters(host=self.host)
-        if self.virtual_host:
-            connection_params.virtual_host = self.virtual_host
+            connection_params = pika.ConnectionParameters(host=self.host, virtual_host=self.virtual_host)
 
         self.conn = pika.BlockingConnection(connection_params)
         self.channel = self.conn.channel()

--- a/sensors/queues_sensor.py
+++ b/sensors/queues_sensor.py
@@ -30,6 +30,7 @@ class RabbitMQQueueSensor(Sensor):
         self.host = self._config["sensor_config"]["host"]
         self.username = self._config["sensor_config"]["username"]
         self.password = self._config["sensor_config"]["password"]
+        self.virtual_host = self._config["sensor_config"]["virtual_host"] if 'virtual_host' in self._config["sensor_config"].keys() else None
 
         queue_sensor_config = self._config["sensor_config"]["rabbitmq_queue_sensor"]
         self.queues = queue_sensor_config["queues"]
@@ -77,6 +78,8 @@ class RabbitMQQueueSensor(Sensor):
             )
         else:
             connection_params = pika.ConnectionParameters(host=self.host)
+        if self.virtual_host:
+            connection_params.virtual_host = self.virtual_host
 
         self.conn = pika.BlockingConnection(connection_params)
         self.channel = self.conn.channel()

--- a/sensors/queues_sensor.py
+++ b/sensors/queues_sensor.py
@@ -77,7 +77,10 @@ class RabbitMQQueueSensor(Sensor):
                 host=self.host, credentials=credentials, virtual_host=self.virtual_host
             )
         else:
-            connection_params = pika.ConnectionParameters(host=self.host, virtual_host=self.virtual_host)
+            connection_params = pika.ConnectionParameters(
+                host=self.host,
+                virtual_host=self.virtual_host
+            )
 
         self.conn = pika.BlockingConnection(connection_params)
         self.channel = self.conn.channel()


### PR DESCRIPTION
Hi there,

This resolves #13 - I've done some limited testing this afternoon and appears to be working as expected - this essentially just adds the same config for virtual hosts from the `publish_message` action into the `RabbitMQQueueSensor` sensor.

Please let me know if this PR needs any adjustments :)